### PR TITLE
Corrected errors found by rake on install.rb and default.rb

### DIFF
--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -17,7 +17,7 @@
 # limitations under the License.
 #
 
-temp_resolv_conf  = DDNSUpdate.resolv_conf
+temp_resolv_conf = DDNSUpdate.resolv_conf
 
 node.default['ddnsupdate']['resolv_conf']['nameservers'] = temp_resolv_conf[:nameservers].first
 node.default['ddnsupdate']['resolv_conf']['search'] = temp_resolv_conf[:search].first

--- a/recipes/install.rb
+++ b/recipes/install.rb
@@ -37,5 +37,5 @@ template node['ddnsupdate']['ddnssec']['file'] do
   owner 'root'
   group 'root'
   source node['ddnsupdate']['ddnssec']['template_source']
-  only_if     { (node['ddnsupdate']['ddnssec']['manage'] && !node['ddnsupdate']['no_dsec']) }
+  only_if { (node['ddnsupdate']['ddnssec']['manage'] && !node['ddnsupdate']['no_dsec']) }
 end


### PR DESCRIPTION
recipes/install.rb:40:10: C: Unnecessary spacing detected.
  only_if     { (node['ddnsupdate']['ddnssec']['manage'] && !node['ddnsupdate']['no_dsec']) }
         ^^^^
recipes/default.rb:20:17: C: Unnecessary spacing detected.
temp_resolv_conf  = DDNSUpdate.resolv_conf

Signed-off-by: Bradley Corner <bcorner@fanatics.com>